### PR TITLE
Release cell reference on prepareForReuse as a fix for iOS 15+ cell l…

### DIFF
--- a/EssentialFeed.xcodeproj/xcuserdata/ashishjaiswal.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/EssentialFeed.xcodeproj/xcuserdata/ashishjaiswal.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,54 @@
    uuid = "08B0A488-AC3B-4DEE-AD6E-A2EEAEFE3C5B"
    type = "1"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "70C241B8-2035-4DE6-8CE1-417A35DC7D78"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "EssentialFeediOS/Feed UI/Views/FeedImageCell.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "30"
+            endingLineNumber = "30"
+            landmarkName = "prepareForReuse()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "16E5F5DE-C398-4144-A56F-C23FF9EADFE1"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "31"
+            endingLineNumber = "31"
+            landmarkName = "display(_:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "590D7AE8-7863-4CE9-BEB1-D9C535FED6A6"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "53"
+            endingLineNumber = "53"
+            landmarkName = "releaseCellAfterReuse()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -35,6 +35,9 @@ final class FeedImageCellController: FeedImageView {
         cell?.feedImageContainer.isShimmering = viewModel.isLoading
         cell?.feedImageRetryButton.isHidden = !viewModel.shouldRetry
         cell?.retry = delegate.didRequestImage
+        cell?.onReuse = { [weak self] in
+            self?.releaseCellAfterReuse()
+        }
     }
     
     func preload() {

--- a/EssentialFeediOS/Feed UI/Views/FeedImageCell.swift
+++ b/EssentialFeediOS/Feed UI/Views/FeedImageCell.swift
@@ -18,8 +18,15 @@ public class FeedImageCell: UITableViewCell {
     @IBOutlet private(set) public var feedImageRetryButton: UIButton!
     
     var retry: (() -> Void)?
+    var onReuse: (() -> Void)?
     
     @IBAction private func retryButtonTapped() {
         retry?()
+    }
+    
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        onReuse?()
     }
 }

--- a/EssentialFeediOSTests/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/FeedViewControllerTests.swift
@@ -273,6 +273,21 @@ final class FeedViewControllerTests: XCTestCase {
         XCTAssertNil(view.renderImage)
     }
     
+    func test_feedImageView_doesNotShowDataFromPreviousRequestWhenCellIsReused() throws {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage(), makeImage()])
+
+        let view0 = try XCTUnwrap(sut.simulatedFeedImageViewVisible(at: 0))
+        view0.prepareForReuse()
+
+        let imageData0 = UIImage.make(withColor: .red).pngData()!
+        loader.completeImageLoading(with: imageData0, at: 0)
+
+        XCTAssertEqual(view0.renderImage, .none, "Expected no image state change for reused view once image loading completes successfully")
+    }
+    
     //Mark:- Helpers
     private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: FeedViewController, loader: LoaderSpy) {
         let loader = LoaderSpy()


### PR DESCRIPTION
…ifecycle changes.

On iOS 15+, for performance reasons, the table view data source may create cells ahead of time using the cellForRow method. So the cell may be created but never go through the whole willDisplayCell/didEndDisplaying lifecycle callbacks as it may never be displayed.

However, we start loading the cell image on cellForRow and only cancel the request on didEndDisplaying. In such cases, there can be a race condition when reusing a cell that was never displayed because the request would carry on and potentially load the wrong image at the wrong index path.