### PR TITLE
fix for iOS 14.5 prefetching behavior change - ensure the reusable ce…

### DIFF
--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -562,6 +562,28 @@ class FeedUIIntegrationTests: XCTestCase {
         XCTAssertEqual(loader.loadedImageURLs, [image.url, image.url, image.url], "Expected no request until previous completes")
     }
     
+    func test_feedImageView_configureViewCorrectlyWhenTransistionFromNearVisibleToVisibleWhileStillPreloadingImages() {
+        let (sut,loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage()])
+        
+        sut.simulateFeedImageViewNearVisible(at: 0)
+        let view0 = sut.simulateFeedImageViewVisible(at: 0)
+        
+        XCTAssertEqual(view0?.renderImage, nil, "Expected no rendered image when view becomes visible while still preloading image")
+        XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action when view becomes visible while still preloading image")
+        XCTAssertEqual(view0?.isShowingImageLoadingIndicator,true, "Expected loading indicator when view become visible while still preloading images")
+        
+        let imageData = UIImage.make(withColor: .red).pngData()!
+        
+        loader.completeImageLoading(with: imageData, at: 0)
+        
+        XCTAssertEqual(view0?.renderImage, imageData, "Expected render image after image preloads successfully")
+        XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action after image preloads successfully")
+        XCTAssertEqual(view0?.isShowingImageLoadingIndicator, false, "Expected no loading indicator after image preload succesfully")
+        
+    }
     //Mark:- Helpers
     private func makeSUT(
         selection: @escaping (FeedImage) -> Void = { _ in },

--- a/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -40,6 +40,8 @@ extension FeedImageCellController:  UITableViewDataSource , UITableViewDelegate,
         cell?.locationContainer.isHidden = viewModel.hasLoaction
         cell?.locationLabel.text = viewModel.location
         cell?.descriptionLabel.text = viewModel.description
+        cell?.feedImageContainer.isShimmering = true
+        cell?.feedImageRetryButton.isHidden = true
         cell?.retry = { [weak self] in
             self?.delegate.didRequestImage()
         }


### PR DESCRIPTION
…lls are reset correctly on `cellForRowAt` data source method because prefetching is more likely to start at the same time cells will become visible on iOS 14.5+ and it could lead to race conditions in the cell configuration.